### PR TITLE
Add activity progress bar

### DIFF
--- a/web/app/scripts/components/activity-progress.js
+++ b/web/app/scripts/components/activity-progress.js
@@ -1,0 +1,69 @@
+'use strict';
+
+var m = require('mithril');
+
+  // A bar that shows where the user is in the activity creation process
+var ActivityProgressComponent = {};
+
+ActivityProgressComponent.oninit = function (vnode) {
+  var state = {
+    steps: [
+      {
+        // The label to show in the UI
+        label: 'What',
+        // The route the label should link to
+        route: '/what',
+        // The name of the corresponding activity model field (this indicates
+        // whether this step can be marked as completed)
+        field: 'category_id'
+      },
+      {
+        label: 'Where',
+        route: '/where',
+        field: 'address'
+      },
+      {
+        label: 'When',
+        route: '/when',
+        field: 'event_at'
+      },
+      {
+        label: 'Confirm',
+        route: '/confirm-activity',
+        field: 'created'
+      }
+    ],
+    // Return true if the user is currently on an activity creation page;
+    // otherwise, return false
+    inProgress: function () {
+      var currentRoute = m.route.get();
+      return state.steps.some(function (step) {
+        return step.route === currentRoute;
+      });
+    }
+  };
+  vnode.state = state;
+};
+
+ActivityProgressComponent.view = function (vnode) {
+  var state = vnode.state;
+  var app = vnode.attrs.app;
+  // This outer container is empty snd unstyled because the inner contents are
+  // shown conditionally
+  return m('div.activity-progress-container', state.inProgress() ? [
+    m('div.activity-progress-bar', [
+      m('div.activity-progress-steps', state.steps.map(function (step, s) {
+        return m('a.activity-progress-step', {
+          href: '#!' + step.route,
+          class: app.activity[step.field] ? 'completed' : 'incomplete'
+        }, [
+          m('div.activity-progress-step-number', {
+          }, s + 1),
+          m('span.activity-progress-label', step.label)
+        ]);
+      }))
+    ])
+  ] : null);
+};
+
+module.exports = ActivityProgressComponent;

--- a/web/app/scripts/components/app.js
+++ b/web/app/scripts/components/app.js
@@ -3,6 +3,7 @@
 var m = require('mithril');
 var App = require('../models/app');
 var Users = require('../models/users');
+var ActivityProgressComponent = require('./activity-progress');
 
 // Object for storing application state shared across all routes
 var app = new App();
@@ -58,7 +59,12 @@ AppComponent.view = function (vnode) {
     // AppComponent acts as a layout which accepts any arbitrary sub-component
     // for content (this is to avoid duplication of static components, such as
     // the header and footer, across several components); see main.js
-    m(vnode.attrs.ContentComponent, {app: app, key: vnode.attrs.key})
+    m('div.page-content', m(vnode.attrs.ContentComponent, {
+      app: app,
+      key: vnode.attrs.key
+    })),
+    // A bar that shows where the user is in the activity creation process
+    m(ActivityProgressComponent, {app: app})
   ];
 };
 

--- a/web/app/scripts/components/confirm-activity.js
+++ b/web/app/scripts/components/confirm-activity.js
@@ -27,14 +27,17 @@ ConfirmActivityComponent.oninit = function (vnode) {
           state.creating = false;
           state.creationError = false;
           state.created = true;
-          // We can reset the persisted activity data now that the activity has
-          // been created
-          app.activity = {};
-          app.save();
+          // This allows other UI components (like activity-progress) to know if
+          // the activity was created successfully
+          app.activity.created = true;
           m.redraw();
           // Display success message for a moment before redirecting to activity
           // page
           setTimeout(function () {
+            // We can reset the persisted activity data now that the activity
+            // has been created
+            app.activity = {};
+            app.save();
             m.route.set('/activity/:key', {key: activity.id});
           }, 1000);
         },

--- a/web/app/scripts/components/where.js
+++ b/web/app/scripts/components/where.js
@@ -56,8 +56,6 @@ WhereComponent.oninit = function (vnode) {
           // If an error occurred while retrieving user's location, or if user
           // denies access to their location, dismiss the geolocation panel
           state.geolocating = false;
-          // Ensure that default location is persisted if geolocation fails
-          state.updateActivityLocation();
           m.redraw();
         });
       } else {

--- a/web/app/styles/_activity-progress.scss
+++ b/web/app/styles/_activity-progress.scss
@@ -1,0 +1,44 @@
+.activity-progress-container {
+  position: relative;
+  z-index: 1000;
+}
+
+.activity-progress-bar {
+  padding: 10px 20px;
+  padding-bottom: 6px;
+  background-color: #fff;
+  box-shadow: 0 -1px 10px rgba(#000, 0.25);
+}
+
+.activity-progress-steps {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.activity-progress-step-number {
+  display: block;
+  $dot-size: 20px;
+  width: $dot-size;
+  height: $dot-size;
+  margin: 0 auto;
+  border-radius: 50%;
+  background-color: $gray;
+  line-height: $dot-size;
+  font-size: 14px;
+  color: darken($gray, 50%);
+  .completed & {
+    background-color: $green;
+    color: #fff;
+  }
+}
+
+.activity-progress-label {
+  display: block;
+  margin-top: 5px;
+  font-size: 12px;
+  color: darken($gray, 50%);
+  .completed & {
+    color: darken($green, 10%);
+  }
+}

--- a/web/app/styles/_general.scss
+++ b/web/app/styles/_general.scss
@@ -21,6 +21,13 @@ main {
   text-align: center;
 }
 
+.page-content {
+  display: flex;
+  flex-direction: column;
+  position: relative;
+  flex-grow: 1;
+}
+
 a {
   color: $blue;
   text-decoration: none;

--- a/web/app/styles/_variables.scss
+++ b/web/app/styles/_variables.scss
@@ -9,3 +9,4 @@ $green: #5b2;
 $teal: #3b9;
 $blue: #39d;
 $purple: #93c;
+$gray: #ccc;

--- a/web/app/styles/main.scss
+++ b/web/app/styles/main.scss
@@ -8,3 +8,4 @@
 @import 'where';
 @import 'when';
 @import 'activity';
+@import 'activity-progress';


### PR DESCRIPTION
This PR adds a bar at the bottom of the app UI which shows where the user is in the activity creation process. The indicator for each step turns green when the corresponding field has been set. The links are also clickable, so a user can easily return to a previous step to change something.

**What:**  
![1-what](https://cloud.githubusercontent.com/assets/872474/25158074/8eadbab0-245a-11e7-9bfd-691b1874996d.png)

**Where:**  
![2-where](https://cloud.githubusercontent.com/assets/872474/25158079/915657f4-245a-11e7-968f-c1f0649d8791.png)

**When:**  
![3-when](https://cloud.githubusercontent.com/assets/872474/25158081/92aa5970-245a-11e7-8992-db325a16f2c4.png)

**Confirm:**  
![4-confirm](https://cloud.githubusercontent.com/assets/872474/25158082/9473b18e-245a-11e7-9f4e-e67c20739f80.png)

**Completed:**  
![5-completed](https://cloud.githubusercontent.com/assets/872474/25158091/98b61c28-245a-11e7-9cc2-2bee06cd73cb.png)

**Created Activity:**  
![6-activity](https://cloud.githubusercontent.com/assets/872474/25158093/9a92a6f6-245a-11e7-96d0-94bed46893ad.png)
